### PR TITLE
Refactoring config info storage, cmake fix, readme update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,12 @@ add_custom_target(build
 
 add_custom_target(testbuild
     COMMAND ${CMAKE_MAKE_PROGRAM}
-    COMMAND ${CMAKE_MAKE_PROGRAM} -C tests
+    COMMAND ${CMAKE_MAKE_PROGRAM} configparsertests
+    COMMAND ${CMAKE_MAKE_PROGRAM} coretests
+    COMMAND ${CMAKE_MAKE_PROGRAM} externalio
+    COMMAND ${CMAKE_MAKE_PROGRAM} logtests
+    COMMAND ${CMAKE_MAKE_PROGRAM} storetests
+    COMMAND ${CMAKE_MAKE_PROGRAM} worktests
     COMMAND ${CMAKE_MAKE_PROGRAM} test ARGS="-V"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Other dependencies can be installed via package utilities.
 For example, on Fedora/CentOS:
 
 ```
-dnf install openssl-devel c-ares c-ares-devel yaml-cpp yaml-cpp-devel libevent libevent-devel
+dnf install openssl-devel c-ares c-ares-devel yaml-cpp yaml-cpp-devel libevent libevent-devel make cmake gcc-c++ rapidxml-devel curl-devel cppunit-devel lcov
 
 make build
 sudo make install

--- a/include/internal/HMState.h
+++ b/include/internal/HMState.h
@@ -79,6 +79,13 @@ public:
      */
     bool setupDaemonstate();
 
+    //! Computes Hash and stores the config info.
+    /*
+         Computes hash  for the entire config and stores in the config Info.
+         \return true if the successful.
+     */
+    bool storeConfigInfo();
+
     //! Get the current master config loaded.
     /*!
          Get the current master config loaded.

--- a/src/internal/HMState.cpp
+++ b/src/internal/HMState.cpp
@@ -71,26 +71,32 @@ HMState::setupDaemonstate()
 
     bool bConfigLoadOk = loadAllConfigs();
 
-    HMConfigInfo configInfo;
-    HMHashMD5 configHash;
-    configInfo.m_version = HM_MDBM_VERSION;
-    configInfo.m_configLoadTime = HMTimeStamp::now();
-    configInfo.m_configStatus = (bConfigLoadOk) ? HM_CONFIG_STATUS_OK : HM_CONFIG_STATUS_ERROR;
-    if(configHash.init())
-    {
-        HashHostGroupMap(configHash, configInfo.m_hash);
-    }
     if(!bConfigLoadOk)
     {
        HMLog(HM_LOG_CRITICAL, "[CORE] Failure loading configs");
        return false;
     }
-    setHash(configInfo.m_hash);
-    m_datastore->storeConfigInfo(configInfo);
-
     generateHostCheckList();
     generateDNSCheckList();
     return true;
+}
+
+bool
+ HMState::storeConfigInfo()
+ {
+    HMConfigInfo configInfo;
+    HMHashMD5 configHash;
+    configInfo.m_version = HM_MDBM_VERSION;
+    configInfo.m_configLoadTime = HMTimeStamp::now();
+    configInfo.m_configStatus = HM_CONFIG_STATUS_OK;
+    if (!configHash.init())
+    {
+        HMLog(HM_LOG_CRITICAL, "[CORE] Failure Initializing Hashing function");
+         return false;
+    }
+    HashHostGroupMap(configHash, configInfo.m_hash);
+    setHash(configInfo.m_hash);
+    return m_datastore->storeConfigInfo(configInfo);
 }
 
 const std::string&

--- a/src/internal/HMStateManager.cpp
+++ b/src/internal/HMStateManager.cpp
@@ -276,6 +276,7 @@ HMStateManager::loadDaemonState(const string& masterConfig, HM_LOG_LEVEL logLeve
         return false;
     }
     m_newState->m_datastore->storeConfigs(*m_newState);
+    m_newState->storeConfigInfo();
     m_currentState.swap(m_newState);
     m_newState.reset();
 
@@ -353,6 +354,7 @@ HMStateManager::reloadDaemonConfigs(const string& masterConfig)
 
     m_currentState.swap(m_newState);
     m_currentState->m_datastore->storeConfigs(*m_currentState);
+    m_newState->storeConfigInfo();
     m_currentState->resheduleDNSChecks(m_newState, m_workQueue);
     m_currentState->resheduleHealthChecks(m_newState, m_workQueue);
     m_currentState->m_dnsCache.queueDNSLookups(m_workQueue, *m_eventLoop, false);


### PR DESCRIPTION
## Description
Refactoring the config info storage to store the hash value after string the configs to the storage. Fixing the build to latest CMake-3.15. Updating the README to add additional dependencies.  

## Related Issue
CMake-3.15 "make test" would not build test files 

## Motivation and Context
Obtaining the config hash while the reload was happening and before the configs are stored. There could be a discrepancy between the configs and its hash 

## How Has This Been Tested?
Existing tests complete without failure. 

## Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X ] My code follows the code style of this project.
- [ X] My change requires a change to the documentation.
- [ X] I have updated the documentation accordingly.
- [ X] I have read the **[CONTRIBUTING](./Contributing.md)** document.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
