### PR TITLE
modifications required for a successful slimbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.11)
 
 include(ExternalProject)
 enable_testing()

--- a/include/internal/HMThreadWorker.h
+++ b/include/internal/HMThreadWorker.h
@@ -3,8 +3,10 @@
 #ifndef INCLUDES_HMTHREADWORKER_H_
 #define INCLUDES_HMTHREADWORKER_H_
 
+#ifdef USE_ARES
+#include <ares.h> 
+#endif 
 #include <cstdint>
-#include <ares.h>
 #include <thread>
 #include <atomic>
 

--- a/include/internal/HMWork.h
+++ b/include/internal/HMWork.h
@@ -4,7 +4,9 @@
 #define HMWORK_H_
 
 #include <thread>
+#ifdef USE_ARES
 #include "ares.h"
+#endif
 
 #include "HMDataCheckParams.h"
 #include "HMDataHostCheck.h"
@@ -28,6 +30,7 @@ class HMDNSCache;
 class HMWorkState
 {
 public:
+    #ifdef USE_ARES
     ares_channel m_channel;
     bool m_aresLoaded;
 
@@ -38,6 +41,7 @@ public:
     HMWorkState(ares_channel channel, bool aresLoaded) :
         m_channel(channel),
         m_aresLoaded(aresLoaded) {};
+    #endif
 
     //! Reload the state. Used during a reload to re-init libraries such as Ares that are init once.
     /*!

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -17,12 +17,14 @@ foreach( file  ${PROTO})
     set (SOURCES ${SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/${name})
     add_custom_command(
 	OUTPUT  ${CMAKE_CURRENT_SOURCE_DIR}/${name}
-	COMMAND ${PROTOBUF_PATH}/bin/protoc --proto_path=${CMAKE_CURRENT_SOURCE_DIR} --cpp_out=${CMAKE_CURRENT_SOURCE_DIR} ${file}
-	COMMAND ${PROTOBUF_PATH}/bin/protoc --proto_path=${CMAKE_CURRENT_SOURCE_DIR} --python_out=${CMAKE_SOURCE_DIR}/api ${file}
+        COMMAND ${PROTOBUF_PATH}/bin/protoc --proto_path=${CMAKE_CURRENT_SOURCE_DIR} 
+        --cpp_out=${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+        COMMAND ${PROTOBUF_PATH}/bin/protoc --proto_path=${CMAKE_CURRENT_SOURCE_DIR} 
+        --python_out=${CMAKE_SOURCE_DIR}/api ${CMAKE_CURRENT_SOURCE_DIR}/${file}
 	DEPENDS ${file}
      )
 
-endforeach( file ${PROTOS} )
+endforeach( file ${PROTO} )
 
 set(CMAKE_BUILD_TYPE Debug)
 set(CPP_FLAGS "-Wall -Wextra -Wchkp -Wfloat-equal -Wl,--copy-dt-needed-entries -Wl,--as-needed -Wl,--no-undefined")

--- a/src/internal/HMDNSCache.cpp
+++ b/src/internal/HMDNSCache.cpp
@@ -8,7 +8,9 @@
 #include "HMConstants.h"
 #include "HMWork.h"
 #include "HMWorkDNSLookup.h"
+#ifdef USE_ARES
 #include "HMWorkDNSLookupAres.h"
+#endif
 #include "HMWorkDNSLookupStatic.h"
 #include "HMLogBase.h"
 #include "HMStorage.h"

--- a/src/internal/HMDNSLookup.cpp
+++ b/src/internal/HMDNSLookup.cpp
@@ -1,7 +1,9 @@
 // Copyright 2019, Oath Inc.
 // Licensed under the terms of the Apache 2.0 license. See LICENSE file in the root of the distribution for licensing details.
 #include <chrono>
+#ifdef USE_ARES 
 #include "ares.h"
+#endif
 
 #include "HMDataHostGroup.h"
 #include "HMDNSLookup.h"

--- a/src/internal/HMHashMD5.cpp
+++ b/src/internal/HMHashMD5.cpp
@@ -10,7 +10,11 @@ using namespace std;
 HMHashMD5::HMHashMD5() :
                 finalized(false)
 {
+     #if OPENSSL_VERSION_NUMBER < 0x10100000L
+     ctx = EVP_MD_CTX_create();
+     #else 
      ctx = EVP_MD_CTX_new();
+     #endif 
 }
 
 bool 
@@ -63,5 +67,9 @@ HMHashMD5::size() const
 HMHashMD5::~HMHashMD5()
 {
     finalized = false;
+    #if OPENSSL_VERSION_NUMBER < 0x10100000L
+    EVP_MD_CTX_destroy(ctx);
+    #else 
     EVP_MD_CTX_free(ctx);
+    #endif 
 }

--- a/src/internal/HMState.cpp
+++ b/src/internal/HMState.cpp
@@ -6,7 +6,9 @@
 
 #include "HMState.h"
 #include "HMConfigParserYaml.h"
+#ifdef USE_MDBM
 #include "HMStorageHostGroupMDBM.h"
+#endif
 #include "HMStorageHostText.h"
 #include "HMLogBase.h"
 

--- a/src/internal/HMThreadWorker.cpp
+++ b/src/internal/HMThreadWorker.cpp
@@ -7,7 +7,9 @@
 #include "HMThreadWorker.h"
 #include "HMWork.h"
 #include "HMWorkDNSLookup.h"
+#ifdef USE_ARES 
 #include "HMWorkDNSLookupAres.h"
+#endif
 #include "HMWorkHealthCheck.h"
 #include "HMWorkHealthCheckCurl.h"
 #include "HMLogBase.h"

--- a/src/internal/HMWork.cpp
+++ b/src/internal/HMWork.cpp
@@ -1,6 +1,8 @@
 // Copyright 2019, Oath Inc.
 // Licensed under the terms of the Apache 2.0 license. See LICENSE file in the root of the distribution for licensing details.
+#ifdef USE_ARES
 #include <ares.h>
+#endif
 #include <cstring>
 
 #include "HMWork.h"


### PR DESCRIPTION

modifications required for a successful slimbuild
## Description
A Few modifcations were required for Header file inclusions to allow for a successful slimbuild of netchasm. Checks for openssl version are needed to use the appropriate API which has changed in openssl version 1.1.0. The CMAKE version also has been set to 3.11. 

## Motivation and Context
These changes are required for the slimbuild to pass

## How Has This Been Tested?
ensured that make slimbuild runs to completion 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTING](./Contributing.md)** document.
- [ ] I have added tests to cover my changes.
- [] All new and existing tests passed.
