### PR TITLE
Add versioning

### DIFF
--- a/include/internal/HMDNSCache.h
+++ b/include/internal/HMDNSCache.h
@@ -106,27 +106,30 @@ public:
          Check to see if we should schedule a DNS resolution for the given lookup.
          \param the hostname to resolve.
          \param structure holding DNS type and address type(v4 or v6).
+         \param version of the current state.
          \return the schedule state. Either queue work, a timeout event or ignore.
      */
-    HM_SCHEDULE_STATE queryNeeded(const std::string& name, const HMDNSLookup& dnsHostCheck) const;
+    HM_SCHEDULE_STATE queryNeeded(const std::string& name, const HMDNSLookup& dnsHostCheck, uint32_t version=0) const;
 
     //! Get the next resolution time based on the timeout.
     /*!
          Get the next resolution time based on the timeout
          \param the host to resolve.
          \param structure holding DNS type and address type(v4 or v6).
+         \version of the current state.
          \return the HMTimeStamp of the next time to schedule a DNS resolution.
      */
-    HMTimeStamp nextQueryTime(const std::string& name, const HMDNSLookup& dnsHostCheck) const;
+    HMTimeStamp nextQueryTime(const std::string& name, const HMDNSLookup& dnsHostCheck, uint32_t version=0) const;
 
     //! Start aDNS query.
     /*!
          Start a DNS query. Update the internal query state to in progress.
          \param the host name to resolve.
          \param structure holding DNS type and address type(v4 or v6).
+         \param version of the query.
          \return the true if succeeds.
      */
-    bool startDNSQuery(const std::string& name, HMDNSLookup& dnsHostCheck);
+    bool startDNSQuery(const std::string& name, HMDNSLookup& dnsHostCheck, uint32_t version=0);
 
     //! Queue the DNS query.
     /*!
@@ -135,7 +138,7 @@ public:
          \param structure holding DNS type and address type(v4 or v6).
          \param the work queue to insert the DNS resolution work.
      */
-    void queueDNSQuery(std::string name, HMDNSLookup& dnsHostCheck, HMWorkQueue& queue);
+    void queueDNSQuery(std::string name, HMDNSLookup& dnsHostCheck, HMWorkQueue& queue, uint32_t version);
 
     //! Queue all the DNS lookups.
     /*!
@@ -144,7 +147,7 @@ public:
          \param the event loop to insert any needed timeouts for DNS resolutions that were loaded from storage.
          \param true if this is a restart during a running daemon config reload.
      */
-    void queueDNSLookups(HMWorkQueue& queue, HMEventLoop& eventLoop, bool restart);
+    void queueDNSLookups(HMWorkQueue& queue, HMEventLoop& eventLoop, bool restart, uint32_t version );
 
     //! Check to see if the given IPAddress has been resolved for the hostname.
     /*!

--- a/include/internal/HMDNSLookup.h
+++ b/include/internal/HMDNSLookup.h
@@ -51,6 +51,10 @@ public:
         m_type(type),
         m_ipv6(ipv6),
         m_plugin(HM_DNS_PLUGIN_NONE) {}
+    HMDNSLookup(HM_DNS_TYPE type, HM_DNS_PLUGIN_CLASS plugin, bool ipv6) :
+       m_type(type),
+       m_ipv6(ipv6),
+       m_plugin(plugin) {}
     HMDNSLookup(HM_DNS_TYPE type, bool ipv6, const std::string& remoteCheck) :
         m_type(type),
         m_ipv6(ipv6),

--- a/include/internal/HMDNSResult.h
+++ b/include/internal/HMDNSResult.h
@@ -25,6 +25,7 @@ public:
 
     HMDNSResult() :
         m_queryState(HM_CHECK_INACTIVE),
+        m_queryVersion(0),
         m_queryTimeout(HM_DEFAULT_DNS_RESOLUTION_TIMEOUT),
         m_dnsTimeout(HM_DEFAULT_DNS_TTL) {};
 
@@ -33,12 +34,14 @@ public:
         m_dnsTimeout = k.m_dnsTimeout;
         m_queryTimeout = k.m_queryTimeout;
         m_queryState = k.m_queryState;
+        m_queryVersion = 0;
         m_queryTime = k.m_queryTime;
         m_resultTime = k.m_resultTime;
     }
 
     HMDNSResult(uint64_t ttl, uint64_t timeout) :
         m_queryState(HM_CHECK_INACTIVE),
+        m_queryVersion(0),
         m_queryTimeout(timeout),
         m_dnsTimeout(ttl) {};
 
@@ -67,30 +70,34 @@ public:
 	/*!
 	     Start the DNS resolution for this result.
 	     Sets the internal state to HM_CHECK_IN_PROGRESS.
+             \param version of the query.
 	     \return the HMTimeStamp with the check timeout value. (To determine when to reschedule in case of timeout.)
 	 */
-	HMTimeStamp startQuery();
+	HMTimeStamp startQuery(uint32_t version=0);
 
 	//! Finish the DNS resolution for this result.
 	/*!
 	     Finish the DNS resolution for this result. Set the internal state to either HM_CHECK_IDLE or HM_CHECK_FAILED.
 	     \param true if the lookup was a success.
+             \param version of the query.
 	 */
 	void finishQuery(bool success);
 
 	//! Determine if the DNS query needs to be run now.
 	/*!
 	     Determine if the DNS query needs to be run now.
+             \param version of the current state.
 	     \return true if the check is expired and needs to be run now.
 	 */
-	bool queryNeeded() const;
+	bool queryNeeded(uint32_t version=0) const;
 
 	//! Determine the time of the next required DNS resolution for this entry.
 	/*!
 	     Determine the time of the next required DNS resolution for this entry.
+             \param version of the current state.
 	     \return HMTimeStamp of the next required DNS resolution for this entry.
 	 */
-	HMTimeStamp nextQueryTime() const;
+	HMTimeStamp nextQueryTime(uint32_t version=0) const;
 
 	//! Get the TTL of this DNS resolution.
 	/*!
@@ -139,6 +146,13 @@ public:
 	 */
     HM_WORK_STATE getQueryState() const;
 
+    //! Get the version of the internal state machine.
+    /*!
+     *   Get the version of the internal state machine.
+     *   \return the version of the check.
+     */
+    uint32_t getQueryVersion() const;
+
     //! Get the last time the DNS resolution occurred.
     /*!
          Get the last time the DNS resolution occurred.
@@ -158,6 +172,7 @@ private:
 	mutable std::shared_timed_mutex m_resultLock;
 
 	HM_WORK_STATE m_queryState;
+        uint32_t m_queryVersion;
 	HMTimeStamp m_queryTime;
 	HMTimeStamp m_resultTime;
 

--- a/include/internal/HMDataCheckList.h
+++ b/include/internal/HMDataCheckList.h
@@ -49,9 +49,10 @@ public:
         \param hostname to check.
         \param ip to check.
         \param hostCheck parameters to use for the check.
+        \param version of the current state.
         \return the schedule state. Either queue work, a timeout event or ignore.
      */
-    HM_SCHEDULE_STATE checkNeeded(std::string& hostname, HMIPAddress& ip, HMDataHostCheck& hostCheck);
+    HM_SCHEDULE_STATE checkNeeded(std::string& hostname, HMIPAddress& ip, HMDataHostCheck& hostCheck, uint32_t version=0);
 
     //! nextCheckTime determines the next timeStamp to conduct the given check.
     /*!
@@ -59,9 +60,10 @@ public:
          \param hostname to check.
          \param ip address to check.
          \param hostCheck parameters to be used for the check.
+         \param version of the current state.
          \return An HMTimeStamp of the time the next check should occur.
      */
-    HMTimeStamp nextCheckTime(std::string& hostname, const HMIPAddress& ip, HMDataHostCheck& hostCheck);
+    HMTimeStamp nextCheckTime(std::string& hostname, const HMIPAddress& ip, HMDataHostCheck& hostCheck, uint32_t version=0);
 
     //! Get the check timeout based on the TTL of this check.
     /*!
@@ -82,8 +84,9 @@ public:
          \param hostCheck data to be used for the check.
          \param the work queue to insert the check.
          \param enable remote check(default is false)
+         \param state version for the check
      */
-    void queueCheck(const std::string& hostname, const HMIPAddress& ip, HMDataHostCheck& check, HMWorkQueue& queue);
+    void queueCheck(const std::string& hostname, const HMIPAddress& ip, HMDataHostCheck& check, HMWorkQueue& queue, uint32_t version);
 
     //! This function is called by the worker thread when the check is removed from the work queue and is executed.
     /*
@@ -92,9 +95,10 @@ public:
          \param hostname of the check.
          \param ip of the check.
          \param hostCheck data to use for the check.
+         \param version of the check.
          \return the timeout of the check. It can be rescheduled if this timeout elapses.
      */
-    HMTimeStamp startCheck(std::string& hostname, HMIPAddress& ip, HMDataHostCheck& check);
+    HMTimeStamp startCheck(std::string& hostname, HMIPAddress& ip, HMDataHostCheck& check, uint32_t version=0);
 
     //! This function retrieves the host groups associated with the given check and check params.
     /*

--- a/include/internal/HMDataCheckParams.h
+++ b/include/internal/HMDataCheckParams.h
@@ -115,16 +115,18 @@ public:
     /*!
          Does this check need to be conducted now.
          \param address the address to check
+         \param version of the current state
          \return bool true if the check should be conducted now.
      */
-    bool checkNeeded(HMIPAddress& address);
+    bool checkNeeded(HMIPAddress& address, uint32_t version=0);
     //! Get the next check time for these check parameters
     /*!
          Get the next check time for the specified address in this check params.
          \param address the address to get the next check time.
+         \param version of the current state
          \return HMTimeStamp the timestamp to schedule the next check for this check params and address.
      */
-    HMTimeStamp nextCheckTime(const HMIPAddress& address);
+    HMTimeStamp nextCheckTime(const HMIPAddress& address, uint32_t version=0);
 
     //! Get the check timeout based on the TTL of this check params.
     /*!
@@ -152,8 +154,9 @@ public:
     /*!
         Set the state machine for this check to running.
         \param the IP address to set
+        \param version of the query
      */
-    void startQuery(HMIPAddress& address);
+    void startQuery(HMIPAddress& address, uint32_t version=0);
 
     //! Check to see if this IP address is currently active.
     /*!
@@ -340,6 +343,14 @@ public:
          \return the work state associated with the passed address.
      */
     HM_WORK_STATE getQueryState(HMIPAddress& address);
+
+    //! Get the version of the internal query state machine.
+    /*
+         Get the version of the internal query state machine.
+         \param the ip address to retrieve the version.
+         \return the work version associated with the passed address.
+    */
+    uint32_t getQueryVersion(HMIPAddress& address);
 
 private:
 

--- a/include/internal/HMDataCheckResult.h
+++ b/include/internal/HMDataCheckResult.h
@@ -157,6 +157,8 @@ public:
     HMTimeStamp m_checkTime;
     //! The current WORK_STATE to track the current state of the check.
     HM_WORK_STATE m_queryState;
+    //! The current query version of the check.
+    uint32_t m_queryVersion;
     //! The last time this remote host was contacted.
     HMTimeStamp m_remoteCheckTime;
     //! Status showing Host went up to down or down to up

--- a/include/internal/HMEventLoop.h
+++ b/include/internal/HMEventLoop.h
@@ -58,8 +58,9 @@ public:
          \param the hostname to resolve.
          \param structure holding DNS type and address type(v4 or v6).
          \param the time Stamp of when the DNS resolution should take place.
+         \param state version that issued the call.
      */
-    virtual void addDNSTimeout(const std::string& hostname, const HMDNSLookup& dnsHostCheck, HMTimeStamp timeStamp) = 0;
+    virtual void addDNSTimeout(const std::string& hostname, const HMDNSLookup& dnsHostCheck, HMTimeStamp timeStamp, uint32_t version) = 0;
 
     //! Add a new Remote timeout.
     /*!
@@ -84,11 +85,13 @@ public:
          \param the IP address to health check.
          \param the host check to conduct.
          \param the time stamp of when the health check should take place.
+         \param state version that issued the call.
      */
     virtual void addHealthCheckTimeout(const std::string& hostname,
             const HMIPAddress& address,
             const HMDataHostCheck hostCheck,
-            HMTimeStamp timeStamp) = 0;
+            HMTimeStamp timeStamp,
+            uint32_t version) = 0;
 protected:
 
     //! The internal run function.

--- a/include/internal/HMEventLoopQueue.h
+++ b/include/internal/HMEventLoopQueue.h
@@ -33,8 +33,9 @@ public:
          \param the hostname to resolve.
          \param true to resolve an IPv6 address.
          \param the time Stamp of when the DNS resolution should take place.
+         \param state version that issued the call
      */
-    void addDNSTimeout(const std::string& hostname, const HMDNSLookup& dnsHostCheck, HMTimeStamp timeStamp);
+    void addDNSTimeout(const std::string& hostname, const HMDNSLookup& dnsHostCheck, HMTimeStamp timeStamp, uint32_t version);
 
     //! Add a new Remote timeout.
     /*!
@@ -61,8 +62,9 @@ public:
          \param the IP address to health check.
          \param the host check to conduct.
          \param the time stamp of when the health check should take place.
+         \param state version that issued the call
      */
-    void addHealthCheckTimeout(const std::string& hostname, const HMIPAddress& address, const HMDataHostCheck hostCheck, HMTimeStamp timeStamp);
+    void addHealthCheckTimeout(const std::string& hostname, const HMIPAddress& address, const HMDataHostCheck hostCheck, HMTimeStamp timeStamp, uint32_t version );
 
     //! Wakeup the tracker.
     /*!
@@ -128,13 +130,15 @@ private:
         TimeoutType m_type;
         HMDNSLookup m_dnsLookup;
         HMIPAddress m_address;
+        uint32_t m_stateVersion;
 
-        Timeout(const std::string& host, HMDNSLookup lookup, const HMTimeStamp expiration)
+        Timeout(const std::string& host, HMDNSLookup lookup, const HMTimeStamp expiration, uint32_t version)
         {
             m_hostname = host;
             m_timeout = expiration;
             m_type = lookup.isIpv6()?DNSV6_TIMEOUT:DNS_TIMEOUT;
             m_dnsLookup = lookup;
+            m_stateVersion = version;
         }
 
         Timeout(const std::string& host, const HMTimeStamp expiration)
@@ -152,13 +156,14 @@ private:
             m_hostCheck = dataHostCheck;
         }
 
-        Timeout(const std::string& host, const HMIPAddress& address, const HMDataHostCheck check, const HMTimeStamp expiration)
+        Timeout(const std::string& host, const HMIPAddress& address, const HMDataHostCheck check, const HMTimeStamp expiration, uint32_t version )
         {
             m_hostname = host;
             m_hostCheck = check;
             m_timeout = expiration;
             m_type = HEALTHCHECK_TIMEOUT;
             m_address = address;
+            m_stateVersion = version;
         }
 
         bool operator< (const Timeout& t) const

--- a/include/internal/HMState.h
+++ b/include/internal/HMState.h
@@ -65,6 +65,7 @@ public:
         m_nMaxThreads(1),
         m_nMinThreads(1),
         m_connectionTimeout(3000),
+        m_stateVersion(0),
         m_logClass(HM_LOG_PLUGIN_TEXT),
         m_logLevel(HM_LOG_NOTICE),
         m_logPath(HM_DEFAULT_LOG_PATH),
@@ -531,6 +532,12 @@ public:
     //! Enable/Disbale lib-event type DNS check
     void setLibEventEnabled(bool libEventEnabled);
 
+    //! Set the state version
+    void setStateVersion(uint32_t version);
+
+    //! Get the state version
+    uint32_t getStateVersion();
+
     //! get the DNS plugin for the set DNS type
     HM_DNS_PLUGIN_CLASS getDNSPlugin(HM_DNS_TYPE dnstype);
 
@@ -594,6 +601,8 @@ private:
     uint32_t m_nMaxThreads;
     uint32_t m_nMinThreads;
     uint64_t m_connectionTimeout;
+
+    uint32_t m_stateVersion;
 
     HM_LOG_PLUGIN_CLASS m_logClass;
     HM_LOG_LEVEL m_logLevel;

--- a/include/internal/HMWork.h
+++ b/include/internal/HMWork.h
@@ -85,7 +85,8 @@ public:
         m_reschedule(true),
         m_storeResults(true),
         m_publish(true),
-        m_mark(0) {};
+        m_mark(0),
+        m_stateVersion(0) {};
 
     HMWork(const std::string& hostname, const HMIPAddress& ip, const HMDataHostCheck& hostcheck) :
         m_hostname(hostname),
@@ -100,7 +101,8 @@ public:
         m_reschedule(true),
         m_storeResults(true),
         m_publish(true),
-        m_mark(0) {};
+        m_mark(0),
+        m_stateVersion(0) {};
 
     //! Called to update the state manager and event loop in case of a reload.
     /*!
@@ -169,6 +171,15 @@ public:
      */
     void setPublish(bool publish);
 
+    //! Called to set the state version .
+    /*!
+         \param value to be set.
+     */
+    void setStateVersion(uint32_t version);
+
+    //! Called to get the state version .
+    uint32_t getStateVersion();
+
     std::string m_hostname;
     HMIPAddress m_ipAddress;
     HMDataHostCheck m_hostCheck;
@@ -188,6 +199,7 @@ protected:
     bool m_storeResults;
     bool m_publish;
     int m_mark;
+    uint32_t m_stateVersion;
 };
 
 #endif /* HMWORKBASE_H_ */

--- a/src/internal/HMState.cpp
+++ b/src/internal/HMState.cpp
@@ -732,17 +732,17 @@ HMState::forceHealthCheck(const string& hostGroup, HMWorkQueue& workQueue)
                             if(*address == HMIPAddress(AF_INET))
                             {
                                 HMDNSLookup dnsHostCheck(dataCheck.getDnsType(), false, hostGroupInfo->second.getRemoteCheck());
-                                m_dnsCache.queueDNSQuery(*it, dnsHostCheck, workQueue);
+                                m_dnsCache.queueDNSQuery(*it, dnsHostCheck, workQueue, getStateVersion());
                             }
                             else if(*address == HMIPAddress(AF_INET6))
                             {
                                 HMDNSLookup dnsHostCheck(dataCheck.getDnsType(), true, hostGroupInfo->second.getRemoteCheck());
-                                m_dnsCache.queueDNSQuery(*it, dnsHostCheck, workQueue);
+                                m_dnsCache.queueDNSQuery(*it, dnsHostCheck, workQueue, getStateVersion());
                             }
                         }
                         else
                         {
-                            m_checkList.queueCheck(*it, *address, dataCheck, workQueue);
+                            m_checkList.queueCheck(*it, *address, dataCheck, workQueue, getStateVersion());
                         }
                     }
                 }
@@ -772,17 +772,17 @@ HMState::forceHealthCheck(const string& hostGroup, const string& hostName, HMWor
                         if(*address == HMIPAddress(AF_INET))
                         {
                             HMDNSLookup dnsHostCheck(dataCheck.getDnsType(), false, hostGroupInfo->second.getRemoteCheck());
-                            m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue);
+                            m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue, getStateVersion());
                         }
                         else if(*address == HMIPAddress(AF_INET6))
                         {
                             HMDNSLookup dnsHostCheck(dataCheck.getDnsType(), true, hostGroupInfo->second.getRemoteCheck());
-                            m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue);
+                            m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue, getStateVersion());
                         }
                     }
                     else
                     {
-                        m_checkList.queueCheck(hostName, *address, dataCheck, workQueue);
+                        m_checkList.queueCheck(hostName, *address, dataCheck, workQueue, getStateVersion());
                     }
                 }
             }
@@ -806,13 +806,13 @@ HMState::forceDNSCheck(const string &hostGroup, HMWorkQueue& workQueue)
                 {
                     HMDNSLookup dnsHostCheck(dataCheck.getDnsType(), false, hostGroupInfo->second.getRemoteCheck());
                     dnsHostCheck.setPlugin(getDNSPlugin(dataCheck.getDnsType()));
-                    m_dnsCache.queueDNSQuery(*it, dnsHostCheck, workQueue);
+                    m_dnsCache.queueDNSQuery(*it, dnsHostCheck, workQueue, getStateVersion());
                 }
                 if(dataCheck.getDualStack() & HM_DUALSTACK_IPV6_ONLY)
                 {
                     HMDNSLookup dnsHostCheck(dataCheck.getDnsType(), true, hostGroupInfo->second.getRemoteCheck());
                     dnsHostCheck.setPlugin(getDNSPlugin(dataCheck.getDnsType()));
-                    m_dnsCache.queueDNSQuery(*it, dnsHostCheck, workQueue);
+                    m_dnsCache.queueDNSQuery(*it, dnsHostCheck, workQueue, getStateVersion());
                 }
             }
         }
@@ -832,13 +832,13 @@ HMState::forceDNSCheck(const string &hostGroup, const string &hostName, HMWorkQu
             {
                 HMDNSLookup dnsHostCheck(dataCheck.getDnsType(), false, hostGroupInfo->second.getRemoteCheck());
                 dnsHostCheck.setPlugin(getDNSPlugin(dataCheck.getDnsType()));
-                m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue);
+                m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue, getStateVersion());
             }
             if(dataCheck.getDualStack() & HM_DUALSTACK_IPV6_ONLY)
             {
                 HMDNSLookup dnsHostCheck(dataCheck.getDnsType(), true, hostGroupInfo->second.getRemoteCheck());
                 dnsHostCheck.setPlugin(getDNSPlugin(dataCheck.getDnsType()));
-                m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue);
+                m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue, getStateVersion());
             }
         }
     }
@@ -864,11 +864,11 @@ HMState::forceDNSCheck(const string &hostName,  HM_DNS_TYPE dnsType, const set<H
     if (ipv4)
     {
         //TODO remote check is provided empty. Need to implement if remote feature is needed for static checks
-        HMDNSLookup dnsHostCheck(dnsType, false);
+        HMDNSLookup dnsHostCheck(dnsType, getDNSPlugin(dnsType), false);
 
         if(m_dnsCache.getDNSResult(hostName, dnsHostCheck, iter))
         {
-            m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue);
+            m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue, getStateVersion());
         }
         else
         {
@@ -881,10 +881,10 @@ HMState::forceDNSCheck(const string &hostName,  HM_DNS_TYPE dnsType, const set<H
     if (ipv6)
     {
         //TODO remote check is provided empty. Need to implement if remote feature is needed for static checks
-        HMDNSLookup dnsHostCheck(dnsType, true);
+        HMDNSLookup dnsHostCheck(dnsType, getDNSPlugin(dnsType), true);
         if (m_dnsCache.getDNSResult(hostName, dnsHostCheck, iter))
         {
-            m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue);
+            m_dnsCache.queueDNSQuery(hostName, dnsHostCheck, workQueue, getStateVersion());
         }
         else
         {
@@ -1050,7 +1050,7 @@ HMState::resheduleHealthChecks(shared_ptr<HMState> src, HMWorkQueue& workQueue)
                     {
                         for(auto address = addresses.begin(); address != addresses.end(); ++address)
                         {
-                            m_checkList.queueCheck(hostName, *address, nDataCheck, workQueue);
+                            m_checkList.queueCheck(hostName, *address, nDataCheck, workQueue, getStateVersion());
                         }
                     }
                 }
@@ -1074,7 +1074,7 @@ HMState::resheduleHealthChecks(shared_ptr<HMState> src, HMWorkQueue& workQueue)
                         string hostName = *hostname;
                         for(auto address = addresses.begin(); address != addresses.end(); ++address)
                         {
-                            m_checkList.queueCheck(hostName, *address, nDataCheck, workQueue);
+                            m_checkList.queueCheck(hostName, *address, nDataCheck, workQueue, getStateVersion());
                         }
                     }
                 }
@@ -1095,7 +1095,7 @@ HMState::resheduleHealthChecks(shared_ptr<HMState> src, HMWorkQueue& workQueue)
                         string hostName = *hostname;
                         for(auto address = addresses.begin(); address != addresses.end(); ++address)
                         {
-                            m_checkList.queueCheck(hostName, *address, nDataCheck, workQueue);
+                            m_checkList.queueCheck(hostName, *address, nDataCheck, workQueue, getStateVersion());
                         }
                     }
                 }
@@ -1119,7 +1119,7 @@ HMState::resheduleHealthChecks(shared_ptr<HMState> src, HMWorkQueue& workQueue)
                 {
                     for(auto address = addresses.begin(); address != addresses.end(); ++address)
                     {
-                        m_checkList.queueCheck(hostName, *address, nDataCheck, workQueue);
+                        m_checkList.queueCheck(hostName, *address, nDataCheck, workQueue, getStateVersion());
                     }
                 }
             }
@@ -1148,7 +1148,7 @@ HMState::resheduleDNSChecks(shared_ptr<HMState> src, HMWorkQueue& workQueue)
                 {
                     if(resultSrcDNS->second.getDNSTTL() < resultDestDNS->second.getDNSTTL())
                     {
-                       m_dnsCache.queueDNSQuery(it->m_hostname, dnsHostCheck, workQueue);
+                       m_dnsCache.queueDNSQuery(it->m_hostname, dnsHostCheck, workQueue, getStateVersion());
                     }
                 }
             }
@@ -1164,7 +1164,7 @@ HMState::resheduleDNSChecks(shared_ptr<HMState> src, HMWorkQueue& workQueue)
                 {
                     if(resultSrcDNS->second.getDNSTTL() < resultDestDNS->second.getDNSTTL())
                     {
-                        m_dnsCache.queueDNSQuery(it->m_hostname, dnsHostCheck, workQueue);
+                        m_dnsCache.queueDNSQuery(it->m_hostname, dnsHostCheck, workQueue, getStateVersion());
                     }
                 }
             }
@@ -1905,4 +1905,14 @@ HM_DNS_PLUGIN_CLASS HMState::getDNSPlugin(HM_DNS_TYPE dnsType)
     }
     HMLog(HM_LOG_ERROR, "[CORE] Invalid DNS type  %s", printDnsType(dnsType));
     return HM_DNS_PLUGIN_NONE;
+}
+
+void HMState::setStateVersion(uint32_t version)
+{
+   m_stateVersion = version;
+}
+
+uint32_t HMState::getStateVersion()
+{
+   return m_stateVersion;
 }

--- a/src/internal/HMWork.cpp
+++ b/src/internal/HMWork.cpp
@@ -98,3 +98,13 @@ void HMWork::setPublish(bool publish)
 {
     m_publish = publish;
 }
+
+uint32_t HMWork::getStateVersion()
+{
+   return m_stateVersion;
+}
+
+void HMWork::setStateVersion(uint32_t version)
+{
+   m_stateVersion = version;
+}

--- a/src/internal/HMWorkAuxFetch.cpp
+++ b/src/internal/HMWorkAuxFetch.cpp
@@ -44,11 +44,11 @@ HM_WORK_STATUS HMWorkAuxFetch::processWork()
         HMTimeStamp checkTime = currentState->m_checkList.nextCheckTime(m_hostname, m_ipAddress, m_hostCheck);
         if(checkTime <= HMTimeStamp::now())
         {
-            currentState->m_checkList.queueCheck(m_hostname, m_ipAddress, m_hostCheck, m_stateManager->m_workQueue);
+            currentState->m_checkList.queueCheck(m_hostname, m_ipAddress, m_hostCheck, m_stateManager->m_workQueue, getStateVersion());
         }
         else
         {
-            m_eventLoop->addHealthCheckTimeout(m_hostname, m_ipAddress, m_hostCheck, checkTime);
+            m_eventLoop->addHealthCheckTimeout(m_hostname, m_ipAddress, m_hostCheck, checkTime, getStateVersion());
         }
     }
     return result;

--- a/src/internal/HMWorkHealthCheck.cpp
+++ b/src/internal/HMWorkHealthCheck.cpp
@@ -30,12 +30,12 @@ HMWorkHealthCheck::processWork()
         m_stateManager->updateState(currentState);
 
         // now conduct the check.
-        m_timeout = currentState->m_checkList.startCheck(m_hostname, m_ipAddress, m_hostCheck);
+        m_timeout = currentState->m_checkList.startCheck(m_hostname, m_ipAddress, m_hostCheck, getStateVersion());
 
         m_workStatus = healthCheck();
     }
 
-    if (m_workStatus)
+    if (m_workStatus && (getStateVersion() == currentState->getStateVersion()))
     {
         // process the results
         // Update the smart pointer if necessary
@@ -54,18 +54,18 @@ HMWorkHealthCheck::processWork()
         }
         if (m_reschedule)
         {
-            HMTimeStamp checkTime = currentState->m_checkList.nextCheckTime(m_hostname, m_ipAddress, m_hostCheck);
+            HMTimeStamp checkTime = currentState->m_checkList.nextCheckTime(m_hostname, m_ipAddress, m_hostCheck, currentState->getStateVersion());
             HMDNSLookup dnsHostCheck(m_hostCheck.getDnsType(), m_ipAddress.getType() == AF_INET6, m_hostCheck.getRemoteCheck());
             bool isValidAddress = currentState->m_dnsCache.isValidAddress(m_hostname, m_hostCheck.getDualStack(), dnsHostCheck, m_ipAddress);
             if (isValidAddress)
             {
                 if (checkTime <= HMTimeStamp::now())
                 {
-                    currentState->m_checkList.queueCheck(m_hostname, m_ipAddress, m_hostCheck, m_stateManager->m_workQueue);
+                    currentState->m_checkList.queueCheck(m_hostname, m_ipAddress, m_hostCheck, m_stateManager->m_workQueue, getStateVersion());
                 }
                 else
                 {
-                    m_eventLoop->addHealthCheckTimeout(m_hostname, m_ipAddress, m_hostCheck, checkTime);
+                    m_eventLoop->addHealthCheckTimeout(m_hostname, m_ipAddress, m_hostCheck, checkTime, getStateVersion());
                 }
             }
         }

--- a/src/internal/HMWorkRemoteCheck.cpp
+++ b/src/internal/HMWorkRemoteCheck.cpp
@@ -72,7 +72,7 @@ HM_WORK_STATUS HMWorkRemoteCheck::processWork()
                         m_hostCheck.getRemoteCheck());
                 lookup.setPlugin(currentState->getDNSPlugin(m_hostCheck.getDnsType()));
                 currentState->m_dnsCache.queueDNSQuery((*hosts)[i], lookup,
-                        m_stateManager->m_workQueue);
+                        m_stateManager->m_workQueue, currentState->getStateVersion());
             }
             if (m_hostCheck.getDualStack() & HM_DUALSTACK_IPV6_ONLY)
             {
@@ -80,7 +80,7 @@ HM_WORK_STATUS HMWorkRemoteCheck::processWork()
                         m_hostCheck.getRemoteCheck());
                 lookup.setPlugin(currentState->getDNSPlugin(m_hostCheck.getDnsType()));
                 currentState->m_dnsCache.queueDNSQuery((*hosts)[i], lookup,
-                        m_stateManager->m_workQueue);
+                        m_stateManager->m_workQueue, currentState->getStateVersion());
             }
         }
     }

--- a/src/internal/HMWorkRemoteHostCheck.cpp
+++ b/src/internal/HMWorkRemoteHostCheck.cpp
@@ -62,7 +62,7 @@ HM_WORK_STATUS HMWorkRemoteHostCheck::processWork()
                     m_hostCheck.getRemoteCheck());
             lookup.setPlugin(currentState->getDNSPlugin(m_hostCheck.getDnsType()));
             currentState->m_dnsCache.queueDNSQuery(m_hostname, lookup,
-                    m_stateManager->m_workQueue);
+                    m_stateManager->m_workQueue, currentState->getStateVersion());
         }
         if (m_hostCheck.getDualStack() & HM_DUALSTACK_IPV6_ONLY)
         {
@@ -70,7 +70,7 @@ HM_WORK_STATUS HMWorkRemoteHostCheck::processWork()
                     m_hostCheck.getRemoteCheck());
             lookup.setPlugin(currentState->getDNSPlugin(m_hostCheck.getDnsType()));
             currentState->m_dnsCache.queueDNSQuery(m_hostname, lookup,
-                    m_stateManager->m_workQueue);
+                    m_stateManager->m_workQueue, currentState->getStateVersion());
         }
     }
     return m_workStatus;

--- a/src/internal/checks_libevent/HMEventLoopLibEvent.cpp
+++ b/src/internal/checks_libevent/HMEventLoopLibEvent.cpp
@@ -271,7 +271,8 @@ HMEventLoopLibEvent::handleDNSTimeout(evutil_socket_t fd, short what, void* arg)
                 data->m_hostname.c_str());
         currentState->m_dnsCache.queueDNSQuery(data->m_hostname,
                 data->m_dnsHostCheck,
-                state->m_workQueue);
+                state->m_workQueue,
+                state->getStateVersion());
     }
     else if (check_state == HM_SCHEDULE_EVENT)
     {
@@ -409,7 +410,8 @@ HMEventLoopLibEvent::handleHealthCheckTimeout(evutil_socket_t fd, short what, vo
                 data->m_hostname.c_str());
         currentState->m_checkList.queueCheck(data->m_hostname,
                 data->m_address, data->m_hostCheck,
-                state->m_workQueue);
+                state->m_workQueue,
+                state->getStateVersion());
     }
     else if (check_state == HM_SCHEDULE_EVENT)
     {

--- a/tests/coreTests/TestHMDataCheckList.cpp
+++ b/tests/coreTests/TestHMDataCheckList.cpp
@@ -74,7 +74,7 @@ void TESTNAME::test_basic_datachecklist()
 	data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )0, queue.queueSize());    
 }
 
@@ -140,7 +140,7 @@ void TESTNAME::test_basic_healthPlugins_tcp()
 	data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )1, queue.queueSize());
     CPPUNIT_ASSERT_EQUAL(true, queue.getWork(work, threadStatus));
     CPPUNIT_ASSERT_EQUAL((uint8_t )HM_CHECK_TCP,
@@ -162,7 +162,7 @@ void TESTNAME::test_basic_healthPlugins_tcp()
 	data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )0, queue.queueSize());    
 }
 
@@ -193,7 +193,7 @@ void TESTNAME::test_basic_healthPlugins_ftp()
 	data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )1, queue.queueSize());
     CPPUNIT_ASSERT_EQUAL(true, queue.getWork(work, threadStatus));
     CPPUNIT_ASSERT_EQUAL((uint8_t )HM_CHECK_FTP,
@@ -213,7 +213,7 @@ void TESTNAME::test_basic_healthPlugins_ftp()
 	data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )0, queue.queueSize());
 }
 
@@ -244,7 +244,7 @@ void TESTNAME::test_basic_healthPlugins_none()
 	data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )1, queue.queueSize());
     CPPUNIT_ASSERT_EQUAL(true, queue.getWork(work, threadStatus));
     CPPUNIT_ASSERT_EQUAL((uint8_t )HM_CHECK_NONE,
@@ -265,7 +265,7 @@ void TESTNAME::test_basic_healthPlugins_none()
 	data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )0, queue.queueSize());
 }
 
@@ -295,7 +295,7 @@ void TESTNAME::test_basic_healthPlugins_dns()
 	data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )1, queue.queueSize());
 }
 
@@ -349,7 +349,7 @@ void TESTNAME::test_basic_healthPlugins_mtls()
     data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )1, queue.queueSize());
     CPPUNIT_ASSERT_EQUAL(true, queue.getWork(work, threadStatus));
     CPPUNIT_ASSERT_EQUAL((uint8_t )HM_CHECK_MTLS_HTTPS,

--- a/tests/coreTests/TestHMDataCheckListAres.cpp
+++ b/tests/coreTests/TestHMDataCheckListAres.cpp
@@ -49,7 +49,7 @@ void TESTNAME::test_basic_healthPlugins_dnsvc()
 	data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )1, queue.queueSize());
     CPPUNIT_ASSERT_EQUAL(true, queue.getWork(work, threadStatus));
     CPPUNIT_ASSERT_EQUAL((uint8_t )HM_CHECK_DNSVC,
@@ -70,7 +70,7 @@ void TESTNAME::test_basic_healthPlugins_dnsvc()
 	data_host.setCheckParams(hostGroup);
     check_list.insertCheck(host_group, host_name, data_host, params, ips);
     check_list.startCheck(host_name, ip, data_host);
-    check_list.queueCheck(host_name, ip, data_host, queue);
+    check_list.queueCheck(host_name, ip, data_host, queue, 0);
     CPPUNIT_ASSERT_EQUAL((uint32_t )0, queue.queueSize());
 }
 


### PR DESCRIPTION
This change adds versioning changes to the state

## Description
After quick consecutive reloads, the workQueue gets filled up with multiple work orders for the same hostname( spawned by states belonging to previous reloads) . This change adds a version to each state and increments it on each reload. With this change, after every check is done, the version of the check is compared with the current state version to see if the check belongs to a previous state and is discarded if so. 
